### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,22 +34,27 @@ class OfflineEdgeLambdaPlugin {
 						options: {
 							port: {
 								usage: 'Specify the port that the server will listen on',
-								default: 8080
+								default: 8080,
+								type: 'string'
 							},
 							cloudfrontPort: {
-								usage: '[Deprecated] Specify the port that the server will listen on. Use --port instead'
+								usage: '[Deprecated] Specify the port that the server will listen on. Use --port instead',
+								type: 'string'
 							},
 							disableCache: {
 								usage: 'Disables simulated cache',
-								default: false
+								default: false,
+								type: 'boolean'
 							},
 							cacheDir: {
 								usage: 'Specify the directory where cache file will be stored',
-								required: false
+								required: false,
+								type: 'string'
 							},
 							fileDir: {
 								usage: 'Specify the directory where origin requests will draw from',
-								required: false
+								required: false,
+								type: 'string'
 							}
 						}
 					}


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - OfflineEdgeLambdaPlugin for "port", "cloudfrontPort", "disableCache", "cacheDir", "fileDir"
```