### PR TITLE
Add hot reloading to server when using serverless webpack or modules built ontop of it

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "watch": "tsc -w",
     "test": "snyk test && echo \"No test specified\"",
     "lint": "tslint --project tsconfig.json",
+    "lint:fix": "tslint --fix --project tsconfig.json",
     "commit": "git-cz",
     "release": "semantic-release --no-ci",
     "release:dry-run": "semantic-release --no-ci --dry-run",

--- a/src/behavior-router.ts
+++ b/src/behavior-router.ts
@@ -38,7 +38,7 @@ export class BehaviorRouter {
 	private started: boolean = false;
 	private origins: Map<string, Origin>;
 	private restarting: boolean = false;
-	private server: Server | null = null
+	private server: Server | null = null;
 	private cacheService: CacheService;
 	private log: (message: string) => void;
 
@@ -78,44 +78,44 @@ export class BehaviorRouter {
 		return this.behaviors.get('*') || null;
 	}
 
-	async start(port: number){
-		this.started = true
-		
+	async start(port: number) {
+		this.started = true;
+
 		return new Promise(async (res, rej) => {
-			await this.listen(port)
+			await this.listen(port);
 
 			// While the server is in a "restarting state" just restart the server
-			while (this.restarting){
-				this.restarting = false
-				await this.listen(port, false)
+			while (this.restarting) {
+				this.restarting = false;
+				await this.listen(port, false);
 			}
 
-			res("Server shutting down ...")
-		})
+			res('Server shutting down ...');
+		});
 	}
 
-	public hasStarted(){
-		return this.started
+	public hasStarted() {
+		return this.started;
 	}
 
-	public isRunning(){
-		return this.server !== null
+	public isRunning() {
+		return this.server !== null;
 	}
 
-	public async restart(){
-		if(this.restarting){
-			return
+	public async restart() {
+		if (this.restarting) {
+			return;
 		}
 
-		this.restarting = true
+		this.restarting = true;
 
-		this.purgeBehaviourFunctions()
-		await this.shutdown()
+		this.purgeBehaviourFunctions();
+		await this.shutdown();
 	}
 
 	private async shutdown() {
-		if(this.server !== null){
-			await this.server.close()
+		if (this.server !== null) {
+			await this.server.close();
 		}
 		this.server = null;
 	}
@@ -124,7 +124,7 @@ export class BehaviorRouter {
 		try {
 			await this.extractBehaviors();
 
-			if(verbose){
+			if (verbose) {
 				this.logStorage();
 				this.logBehaviors();
 			}
@@ -182,7 +182,7 @@ export class BehaviorRouter {
 				this.server = createServer(app);
 				this.server.listen(port);
 				this.server.on('close', (e: string) => {
-					resolve(e)
+					resolve(e);
 				});
 			});
 		} catch (err) {
@@ -249,8 +249,8 @@ export class BehaviorRouter {
 
 	private purgeBehaviourFunctions() {
 		this.behaviors.forEach((behavior) => {
-			behavior.purgeLoadedFunctions()
-		})
+			behavior.purgeLoadedFunctions();
+		});
 	}
 
 	private logStorage() {

--- a/src/function-set.ts
+++ b/src/function-set.ts
@@ -15,7 +15,7 @@ const identityRequestHandler = async (event: CloudFrontRequestEvent) => event.Re
 const identityResponseHandler = async (event: CloudFrontResponseEvent) => event.Records[0].cf.response;
 
 export class FunctionSet {
-	protected readonly moduleLoader: ModuleLoader = new ModuleLoader
+	protected readonly moduleLoader: ModuleLoader = new ModuleLoader();
 
 	public readonly regex: RegExp;
 

--- a/src/function-set.ts
+++ b/src/function-set.ts
@@ -5,7 +5,7 @@ import globToRegExp from 'glob-to-regexp';
 
 import { Origin } from './services';
 import { EventType } from './types';
-import { CallbackPromise, loadModule } from './utils';
+import { CallbackPromise, ModuleLoader} from './utils';
 
 
 export type AsyncCloudFrontRequestHandler = (event: CloudFrontRequestEvent, context: Context) => Promise<CloudFrontRequestResult>;
@@ -15,6 +15,8 @@ const identityRequestHandler = async (event: CloudFrontRequestEvent) => event.Re
 const identityResponseHandler = async (event: CloudFrontResponseEvent) => event.Records[0].cf.response;
 
 export class FunctionSet {
+	protected readonly moduleLoader: ModuleLoader = new ModuleLoader
+
 	public readonly regex: RegExp;
 
 	viewerRequest: Annotated<AsyncCloudFrontRequestHandler> = identityRequestHandler;
@@ -52,7 +54,7 @@ export class FunctionSet {
 	}
 
 	async getRequestHandler(path: string): Promise<AsyncCloudFrontRequestHandler> {
-		const fn = await loadModule(path);
+		const fn = await this.moduleLoader.loadModule(path);
 
 		const handler = async (event: CloudFrontRequestEvent, context: Context) => {
 			const promise = new CallbackPromise();
@@ -76,7 +78,7 @@ export class FunctionSet {
 	}
 
 	async getResponseHandler(path: string): Promise<AsyncCloudFrontResponseHandler> {
-		const fn = await loadModule(path);
+		const fn = await this.moduleLoader.loadModule(path);
 
 		const handler = async (event: CloudFrontResponseEvent, context: Context) => {
 			const deferred = new CallbackPromise();
@@ -92,5 +94,9 @@ export class FunctionSet {
 		handler.path = path;
 
 		return handler;
+	}
+
+	public purgeLoadedFunctions() {
+		this.moduleLoader.purgeLoadedModules()
 	}
 }

--- a/src/function-set.ts
+++ b/src/function-set.ts
@@ -97,6 +97,6 @@ export class FunctionSet {
 	}
 
 	public purgeLoadedFunctions() {
-		this.moduleLoader.purgeLoadedModules()
+		this.moduleLoader.purgeLoadedModules();
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,12 +89,12 @@ class OfflineEdgeLambdaPlugin {
 	async onReload() {
 		// In the event we have not started the server yet or we are in the process of
 		// restarting the server ignore our changes
-		if (!this.server.hasStarted() || !this.server.isRunning()){
-			return
+		if (!this.server.hasStarted() || !this.server.isRunning()) {
+			return;
 		}
 
-		console.log("Restarting server due to function update...")
-		await this.server.restart()
+		console.log('Restarting server due to function update...');
+		await this.server.restart();
 	}
 
 	private prepareCustomSection() {

--- a/src/utils/clear-module.ts
+++ b/src/utils/clear-module.ts
@@ -1,0 +1,73 @@
+/*
+ * <3 Lovingly borrowed from https://github.com/dherault/serverless-offline/blob/master/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
+ */
+import * as path from "path";
+import * as fs from "fs";
+
+interface ClearModuleOpts {
+    cleanup: boolean
+}
+
+export const clearModule = (filePath: string, opts: ClearModuleOpts) => {
+	const options = opts ?? {};
+
+    if(!require || !require.cache){
+        return
+    }
+
+	if (!require.cache[filePath]) {
+		const dirname = path.dirname(filePath);
+		for (const fn of fs.readdirSync(dirname)) {
+			const fullPath = path.resolve(dirname, fn);
+			if (
+				fullPath.substr(0, filePath.length + 1) === `${filePath}.` &&
+				require.cache[fullPath]
+			) {
+				filePath = fullPath;
+				break;
+			}
+		}
+	}
+    
+	if (require.cache[filePath]) {
+
+		// Remove file from parent cache
+		if (require?.cache[filePath]?.parent) {
+			let i = require?.cache[filePath]?.parent?.children.length;
+			if (i) {
+				do {
+					i -= 1;
+					if (require?.cache[filePath]?.parent?.children[i].id === filePath) {
+						require?.cache[filePath]?.parent?.children.splice(i, 1);
+					}
+				} while (i);
+			}
+		}
+		const cld = require?.cache[filePath]?.children;
+		delete require.cache[filePath];
+		for (const c of cld as NodeJS.Module[]) {
+			// Unload any non node_modules children
+			if (!c.filename.match(/node_modules/)) {
+				clearModule(c.id, { ...options, cleanup: false });
+			}
+		}
+		if (opts.cleanup) {
+			// Cleanup any node_modules that are orphans
+			let cleanup = false;
+			do {
+				cleanup = false;
+				for (const fn of Object.keys(require.cache)) {
+					if (
+						require?.cache[fn]?.id !== "." &&
+						require?.cache[fn]?.parent &&
+						require?.cache[fn]?.parent?.id !== "." &&
+						!require.cache[require?.cache[fn]?.parent?.id as string]
+					) {
+						delete require.cache[fn];
+						cleanup = true;
+					}
+				}
+			} while (cleanup);
+		}
+	}
+};

--- a/src/utils/clear-module.ts
+++ b/src/utils/clear-module.ts
@@ -1,19 +1,20 @@
 /*
- * <3 Lovingly borrowed from https://github.com/dherault/serverless-offline/blob/master/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
+ * <3 Lovingly borrowed from
+ * https://github.com/dherault/serverless-offline/blob/master/src/lambda/handler-runner/in-process-runner/InProcessRunner.js
  */
-import * as path from "path";
-import * as fs from "fs";
+import * as path from 'path';
+import * as fs from 'fs';
 
 interface ClearModuleOpts {
-    cleanup: boolean
+	cleanup: boolean;
 }
 
 export const clearModule = (filePath: string, opts: ClearModuleOpts) => {
 	const options = opts ?? {};
 
-    if(!require || !require.cache){
-        return
-    }
+	if (!require || !require.cache) {
+		return;
+	}
 
 	if (!require.cache[filePath]) {
 		const dirname = path.dirname(filePath);
@@ -28,7 +29,7 @@ export const clearModule = (filePath: string, opts: ClearModuleOpts) => {
 			}
 		}
 	}
-    
+
 	if (require.cache[filePath]) {
 
 		// Remove file from parent cache
@@ -58,9 +59,9 @@ export const clearModule = (filePath: string, opts: ClearModuleOpts) => {
 				cleanup = false;
 				for (const fn of Object.keys(require.cache)) {
 					if (
-						require?.cache[fn]?.id !== "." &&
+						require?.cache[fn]?.id !== '.' &&
 						require?.cache[fn]?.parent &&
-						require?.cache[fn]?.parent?.id !== "." &&
+						require?.cache[fn]?.parent?.id !== '.' &&
 						!require.cache[require?.cache[fn]?.parent?.id as string]
 					) {
 						delete require.cache[fn];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,4 +9,5 @@ export * from './convert-to-cf-event';
 export * from './deferred-promise';
 export * from './is-response-result';
 export * from './load-module';
+export * from './clear-module';
 export * from './to-result-response';

--- a/src/utils/load-module.ts
+++ b/src/utils/load-module.ts
@@ -1,17 +1,34 @@
 import { resolve } from 'path';
+import {clearModule} from './clear-module';
 
-export async function loadModule(path: string): Promise<Function> {
-	const regex = /(.+)\.(.+)/;
-	const match = regex.exec(path);
+export class ModuleLoader {
+	protected loadedModules :string[] = []
 
-	if (!match) {
-		throw new Error('Could not find module');
+	async loadModule(path: string): Promise<Function> {
+		const regex = /(.+)\.(.+)/;
+		const match = regex.exec(path);
+	
+		if (!match) {
+			throw new Error('Could not find module');
+		}
+	
+		const [, modulePath, functionName] = match;
+		const absPath = resolve(modulePath);
+	
+		const module = await import(absPath);
+
+		this.loadedModules.push(absPath)
+	
+		return module[functionName];
 	}
 
-	const [, modulePath, functionName] = match;
-	const absPath = resolve(modulePath);
+	public purgeLoadedModules(){
+		this.loadedModules.forEach((module) => {
+			clearModule(module, {
+				cleanup: true
+			})
+		})
 
-	const module = await import(absPath);
-
-	return module[functionName];
+		this.loadedModules = []
+	}
 }

--- a/src/utils/load-module.ts
+++ b/src/utils/load-module.ts
@@ -2,33 +2,33 @@ import { resolve } from 'path';
 import {clearModule} from './clear-module';
 
 export class ModuleLoader {
-	protected loadedModules :string[] = []
+	protected loadedModules: string[] = [];
 
 	async loadModule(path: string): Promise<Function> {
 		const regex = /(.+)\.(.+)/;
 		const match = regex.exec(path);
-	
+
 		if (!match) {
 			throw new Error('Could not find module');
 		}
-	
+
 		const [, modulePath, functionName] = match;
 		const absPath = resolve(modulePath);
-	
+
 		const module = await import(absPath);
 
-		this.loadedModules.push(absPath)
-	
+		this.loadedModules.push(absPath);
+
 		return module[functionName];
 	}
 
-	public purgeLoadedModules(){
+	public purgeLoadedModules() {
 		this.loadedModules.forEach((module) => {
 			clearModule(module, {
 				cleanup: true
-			})
-		})
+			});
+		});
 
-		this.loadedModules = []
+		this.loadedModules = [];
 	}
 }


### PR DESCRIPTION
# What:
 Aims to fix #113

# Why:
 Currently nodeamon needs to be used in order to hot load modules this is not ideal and slow. This aims to leverage the "hot reloading" mechanisms exposed in `serverless webpack` see https://github.com/serverless-heaven/serverless-webpack/blob/2a47679107288f9ce3f61a40db9b32b57f581778/index.js#L169 for more details on this.
 
 # How:
 The server restarts when changes are detected (The Behaviour Router has been refactored to match this approach) and the node modules that need to be reloaded get purged using the same mechanisms serverless offline currently use to internally purge local caches.
 
 # Caveats
 Given this uses the same mechanisms serverless offline uses to purge modules we do inherit some of the hot reload issues that that service has (Like type orm not persisting connections ect.) but this should be better than the current state of affairs (where hot reloading just does not work) 