### PR TITLE
Fix issues with http requests

### DIFF
--- a/src/services/origin.service.ts
+++ b/src/services/origin.service.ts
@@ -123,7 +123,7 @@ export class Origin {
 			method: request.method,
 			protocol: baseUrl.protocol,
 			hostname: baseUrl.hostname,
-			port: baseUrl.port || (baseUrl.protocol === 'https:') ? 443 : 80,
+			port: baseUrl.port || (baseUrl.protocol === 'https:' ? 443 : 80),
 			path: uri.path,
 			headers: {
 				...headers,

--- a/src/services/origin.service.ts
+++ b/src/services/origin.service.ts
@@ -144,7 +144,9 @@ export class Origin {
 				});
 				res.on('error', (err: Error) => reject(err));
 			});
-
+			if (request.body && request.body.data) {
+				req.write(request.body.data);
+			}
 			req.end();
 		});
 	}


### PR DESCRIPTION
Hi!

First of all, thank you for creating this awesome plugin. 

I noticed two small issues while trying to work with the plugin for http requests:

1. The port of the provided baseUrl is always overridden with 443.
2. The request body is not added to POST requests.

I fixed both in this PR. Hopefully you can merge it. Cheers!