### PR TITLE
feat: add function name to context and event headers

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-16.14.2
+lts/gallium

--- a/README.md
+++ b/README.md
@@ -107,3 +107,25 @@ custom:
     interval: 500,
     debounce: 750
 ```
+
+### Options
+
+#### `--headersFile`
+
+Default: _undefined_
+
+CloudFront [injects some headers](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-cloudfront-headers.html) into the request. You can set these by creating a JSON file and passing its path as an option.
+
+Example:
+
+```json
+// .cf-headers.json
+{
+    "CloudFront-Viewer-Country": "us",
+    "CloudFront-Viewer-Country-Region": "tx"
+}
+```
+
+```bash
+npx serverless offline start --headersFile .cf-headers.json
+```

--- a/src/function-set.ts
+++ b/src/function-set.ts
@@ -28,7 +28,8 @@ export class FunctionSet {
 		public readonly pattern: string,
 		public readonly distribution: string,
 		private readonly log: (message: string) => void,
-		public readonly origin: Origin = new Origin()
+		public readonly origin: Origin = new Origin(),
+		public readonly name: string = ''
 	) {
 		this.regex = globToRegExp(pattern);
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,11 @@ class OfflineEdgeLambdaPlugin {
 								usage: 'Specify the directory where origin requests will draw from',
 								required: false,
 								type: 'string'
+							},
+							headersFile: {
+								usage: 'Specify the file (JSON) where injected CloudFront headers will be taken from',
+								required: false,
+								type: 'string'
 							}
 						}
 					}

--- a/src/types/serverless.types.ts
+++ b/src/types/serverless.types.ts
@@ -76,6 +76,7 @@ export interface ServerlessOptions {
 	disableCache: boolean;
 	fileDir: string;
 	port: number;
+	headersFile: string;
 }
 
 export interface EdgeLambdaOptions {
@@ -85,6 +86,7 @@ export interface EdgeLambdaOptions {
 }
 
 export interface ServerlessFunction {
+	name: string;
 	handler: string;
 	package: ServerlessPackage;
 	lambdaAtEdge: EdgeLambdaOptions;

--- a/src/utils/convert-to-cf-event.ts
+++ b/src/utils/convert-to-cf-event.ts
@@ -1,22 +1,34 @@
 import { CloudFrontRequestEvent } from 'aws-lambda';
 import { IncomingMessage } from 'http';
+import fs from 'fs';
 import { parse, UrlWithStringQuery } from 'url';
 
 import { CloudFrontConfig } from '../types';
 import { toCloudFrontHeaders } from './convert-headers';
 
+function readInjectedHeadersFile(injectedHeadersFile: string): Record<string, string> {
+	const headers = fs.readFileSync(injectedHeadersFile, 'utf8');
+	return JSON.parse(headers);
+}
 
 export type IncomingMessageWithBodyAndCookies = IncomingMessage & {
 	body: any;
 	cookies: Record<string, string>;
 };
 
-export function convertToCloudFrontEvent(req: IncomingMessageWithBodyAndCookies, config: CloudFrontConfig): CloudFrontRequestEvent {
+export function convertToCloudFrontEvent(
+	req: IncomingMessageWithBodyAndCookies,
+	config: CloudFrontConfig,
+	injectedHeadersFile?: string
+): CloudFrontRequestEvent {
 	const url = parse(req.url as string, false) as UrlWithStringQuery;
+
+	const injectedHeaders = injectedHeadersFile ? readInjectedHeadersFile(injectedHeadersFile) : {};
+
 	const request = {
 		clientIp: req.socket.remoteAddress as string,
 		method: req.method as string,
-		headers: toCloudFrontHeaders(req.headers),
+		headers: toCloudFrontHeaders({...req.headers, ...injectedHeaders}),
 		uri: url.pathname as string,
 		querystring:  url.query || '',
 		body: req.body,


### PR DESCRIPTION
- Provides the function name in the `Context`
- Allows emulation of CloudFront's injected headers by providing them in a json file
- Updates the README